### PR TITLE
Add cloned repo to the change directory command

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ aws codebuild list-source-credentials
 
 ### Launch infrastructure with AWS Cloud Developement Kit (CDK)
 
-Navigate to the `cdk-v2` directory and run the following commands:
+Navigate to the `cdk-v2` directory of the cloned repo and run the following commands:
 
 ```bash
-cd cdk-v2
+cd amazon-ecs-fargate-cdk-v2-cicd/cdk-v2
 cdk init
 npm install
 npm run build


### PR DESCRIPTION
*Issue #, if available:*
If you follow copy-paste the entire `README.md` the `cd cdk-v2` will not work because you never cd to the cloned repo.
*Description of changes:*
Changing the `cd cdk-v2` to `cd REPO_NAME/cdk-v2` to make it work

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
